### PR TITLE
Add support for Scala Enumerations and List

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Supported types
  - `Double`
  - `ObjectId`
  - `UUID`
+ - `Enumeration`
  - `java.time.Instant`
  - `Option[_]`
  - `Either[_,_]`

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Supported types
  - `Either[_,_]`
  - `Seq[_]`
  - `Set[_]`
+ - `List[_]`
  - `Map[_,_]`
  - Simple monomorphic and non recursive ADTs
 

--- a/lib/src/main/scala/ai/snips/bsonmacros/Macros.scala
+++ b/lib/src/main/scala/ai/snips/bsonmacros/Macros.scala
@@ -12,7 +12,7 @@ import org.mongodb.scala.bson.ObjectId
 
 import scala.collection.concurrent
 import scala.language.experimental.macros
-import scala.reflect.{ classTag, ClassTag }
+import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 import scala.reflect.macros.whitebox
 import scala.util.Try

--- a/lib/src/main/scala/ai/snips/bsonmacros/package.scala
+++ b/lib/src/main/scala/ai/snips/bsonmacros/package.scala
@@ -4,11 +4,29 @@ import org.bson._
 import org.bson.codecs._
 import org.bson.codecs.configuration._
 
+import scala.reflect.runtime.universe._
 import scala.reflect._
 
 package object bsonmacros {
 
-  def toDBObject(a: Any)(implicit repo: CodecRegistry): BsonDocument = {
+	private val mirror: Mirror = runtimeMirror(getClass.getClassLoader)
+
+	def reflectEnum[T: TypeTag](name: String): T = {
+		typeOf[T] match {
+			case valueType @ TypeRef(enumType, _, _) =>
+				val methodSymbol = enumType.member(newTermName("withName")).asMethod
+				val moduleSymbol = enumType.termSymbol.asModule
+				reflect(moduleSymbol, methodSymbol)(name).asInstanceOf[T]
+		}
+	}
+
+	private def reflect(module: ModuleSymbol, method: MethodSymbol)(args: Any*): Any = {
+		val moduleMirror = mirror.reflectModule(module)
+		val instanceMirror = mirror.reflect(moduleMirror.instance)
+		instanceMirror.reflectMethod(method)(args:_*)
+	}
+
+	def toDBObject(a: Any)(implicit repo: CodecRegistry): BsonDocument = {
     val codec: Encoder[Any] = repo.get(a.getClass).asInstanceOf[Encoder[Any]]
     val doc = new BsonDocument()
     val writer = new BsonDocumentWriter(doc)

--- a/lib/src/test/scala/ai/snips/bsonmacros/BsonMacrosTest.scala
+++ b/lib/src/test/scala/ai/snips/bsonmacros/BsonMacrosTest.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 import org.bson.types.ObjectId
 import org.mongodb.scala.bson.{BsonDocument, BsonInt64, BsonObjectId, ObjectId}
 import org.scalatest._
+import TauEnum.TauEnum
 
 class BsonMacrosTest extends FlatSpec with Matchers {
 
@@ -214,15 +215,6 @@ class BsonMacrosTest extends FlatSpec with Matchers {
 		fromDBObject[Quoppa](toDBObject(q)) should be(q)
 	}
 
-	case class San(x: ObjectId, y: UUID)
-	CodecGen[San](registry)
-
-	"ObjectId and UUID" should "work" in {
-		val a = San(ObjectId.get(), UUID.randomUUID())
-		fromDBObject[San](toDBObject(a)) should be(a)
-	}
-
-
 	case class Rho(_id: BsonObjectId, value: Either[String, Int])
 
 	CodecGen[Rho](registry)
@@ -234,5 +226,29 @@ class BsonMacrosTest extends FlatSpec with Matchers {
 		val right = Rho(org.mongodb.scala.bson.BsonObjectId(), Right(42))
 		toDBObject(right) shouldBe BsonDocument("_id" -> right._id, "value" -> BsonDocument("right" -> 42))
 		fromDBObject[Rho](toDBObject(right)) should be(right)
+	}
+
+	case class San(x: ObjectId, y: UUID)
+	CodecGen[San](registry)
+
+	"ObjectId and UUID" should "work" in {
+		val a = San(ObjectId.get(), UUID.randomUUID())
+		fromDBObject[San](toDBObject(a)) should be(a)
+	}
+
+	case class Tau(_id: BsonObjectId, a: Map[TauEnum, String], b: TauEnum, c: Seq[TauEnum])
+
+	CodecGen[Tau](registry)
+	"Tau" should "support Enumeration" in {
+		val enum = Tau(org.mongodb.scala.bson.BsonObjectId(), Map(TauEnum.One -> "One"), TauEnum.Two, Seq(TauEnum.Two))
+		fromDBObject[Tau](toDBObject(enum)) should be(enum)
+	}
+
+	case class Upsilon(_id: BsonObjectId, a: List[String], b: List[Int])
+
+	CodecGen[Upsilon](registry)
+	"Upsilon" should "support List" in {
+		val a = Upsilon(org.mongodb.scala.bson.BsonObjectId(), List("One", "Two", "Three"), List(1, 2, 3))
+		fromDBObject[Upsilon](toDBObject(a)) should be(a)
 	}
 }

--- a/lib/src/test/scala/ai/snips/bsonmacros/TauEnum.scala
+++ b/lib/src/test/scala/ai/snips/bsonmacros/TauEnum.scala
@@ -1,0 +1,6 @@
+package ai.snips.bsonmacros
+
+object TauEnum extends Enumeration {
+	type TauEnum = Value
+	val One, Two, Three = Value
+}


### PR DESCRIPTION
1) Even though Scala's enumerations really aren't the best they are part of the core language.
So have added support for them being used on their own but also as keys for Maps as well as in Lists etc.

2) List collection type is very common and so adding its support would be useful.